### PR TITLE
update setupCanvas to have no minus value of rotatedBox Width, height (cos & sin)

### DIFF
--- a/src/cropperjs-gif.js
+++ b/src/cropperjs-gif.js
@@ -125,8 +125,8 @@ GifCropper.prototype.decode = function(arraybuffer, callback){
 GifCropper.prototype.setupCanvas = function(cropArea, limitRatio) {
     // 计算图片旋转后的尺寸和切剪后的尺寸， 取最大的一方作为container的尺寸
     var radian = Math.PI/180*cropArea.rotate;
-    var rotatedBoxWidth = (this.width*Math.cos(radian)+this.height*Math.sin(radian)) * limitRatio;
-    var rotatedBoxHeight = (this.height*Math.cos(radian)+this.width*Math.sin(radian)) * limitRatio;
+    var rotatedBoxWidth = (this.width*Math.abs(Math.cos(radian))+this.height*Math.abs(Math.sin(radian))) * limitRatio;
+    var rotatedBoxHeight = (this.height*Math.abs(Math.cos(radian))+this.width*Math.abs(Math.sin(radian))) * limitRatio;
     
     this.offsetX = -Math.min(cropArea.x, 0);
     this.offsetY = -Math.min(cropArea.y, 0);


### PR DESCRIPTION
Thanks for gif cropperjs lib it helps me a lot in my project,
but I found an issue about rotated area crop.

`when cropping rotated(-45) area, it crops different area.`
I think when calculate rotatedBoxSize, cos & sin value `should not be minus`
please check this issue
https://github.com/wmlgl/cropperjs-gif/issues/10